### PR TITLE
Register users manually

### DIFF
--- a/PS2 Assistant/Attributes/Preconditions/RequireGuildPermissionAttribute.cs
+++ b/PS2 Assistant/Attributes/Preconditions/RequireGuildPermissionAttribute.cs
@@ -1,0 +1,33 @@
+﻿using Discord;
+using Discord.Interactions;
+using Discord.WebSocket;
+
+namespace PS2_Assistant.Attributes.Preconditions
+{
+    /// <summary>
+    /// Requires the user to have a specific permission
+    /// </summary>
+    public class RequireGuildPermissionAttribute : PreconditionAttribute
+    {
+        private readonly GuildPermission _guildPermission;
+
+        /// <summary>
+        /// Requires the user to have a specific permission
+        /// </summary>
+        /// <param name="guildPermission">The required permission. Multiple can be selected by using <code>|</code></param>
+        public RequireGuildPermissionAttribute(GuildPermission guildPermission)
+        {
+            _guildPermission = guildPermission;
+        }
+
+        public override Task<PreconditionResult> CheckRequirementsAsync(IInteractionContext context, ICommandInfo commandInfo, IServiceProvider services)
+        {
+            if (context.User is not SocketGuildUser socketGuildUser)
+                return Task.FromResult(PreconditionResult.FromError("Interaction didn't occur inside a guild"));
+            if (!socketGuildUser.GuildPermissions.Has(_guildPermission))
+                return Task.FromResult(PreconditionResult.FromError("User does not have the required permissions"));
+
+            return Task.FromResult(PreconditionResult.FromSuccess());
+        }
+    }
+}

--- a/PS2 Assistant/Handlers/InteractionHandler.cs
+++ b/PS2 Assistant/Handlers/InteractionHandler.cs
@@ -45,10 +45,16 @@ namespace PS2_Assistant.Handlers
                 switch (result.Error)
                 {
                     case InteractionCommandError.UnmetPrecondition:
+                        if (context.Interaction.HasResponded)
+                            await context.Interaction.FollowupAsync($"Unmet precondition: {result.ErrorReason}");
+                        else
                         await context.Interaction.RespondAsync($"Unmet precondition: {result.ErrorReason}");
                         _logger.SendLog(LogEventLevel.Warning, context.Guild.Id, result.ErrorReason, caller: info.MethodName);
                         break;
                     default:
+                        if (context.Interaction.HasResponded)
+                            await context.Interaction.FollowupAsync($"An error occurred while executing: {result.ErrorReason}");
+                        else
                         await context.Interaction.RespondAsync($"An error occurred while executing: {result.ErrorReason}");
                         break;
                 }

--- a/PS2 Assistant/Handlers/InteractionHandler.cs
+++ b/PS2 Assistant/Handlers/InteractionHandler.cs
@@ -32,6 +32,7 @@ namespace PS2_Assistant.Handlers
         {
             _interactionService.Log += LogHandler;
             _interactionService.SlashCommandExecuted += SlashCommandExecutedHandler;
+            _interactionService.ComponentCommandExecuted += ComponentCommandExecutedHandler;
             await _interactionService.AddModulesAsync(Assembly.GetEntryAssembly(), _services);
 
             _client.Ready += ClientReadyHandler;
@@ -40,22 +41,33 @@ namespace PS2_Assistant.Handlers
 
         private async Task SlashCommandExecutedHandler(SlashCommandInfo info, IInteractionContext context, IResult result)
         {
+            await CheckResultAsync(info, context, result);
+        }
+
+        private async Task ComponentCommandExecutedHandler(ComponentCommandInfo info, IInteractionContext context, IResult result)
+        {
+            await CheckResultAsync(info, context, result);
+        }
+
+        private async Task CheckResultAsync(ICommandInfo info, IInteractionContext context, IResult result)
+        {
             if (!result.IsSuccess)
             {
                 switch (result.Error)
                 {
                     case InteractionCommandError.UnmetPrecondition:
                         if (context.Interaction.HasResponded)
-                            await context.Interaction.FollowupAsync($"Unmet precondition: {result.ErrorReason}");
+                            await context.Interaction.FollowupAsync($"Unmet precondition for user <@{context.User.Id}>: {result.ErrorReason}", allowedMentions: AllowedMentions.None);
                         else
-                        await context.Interaction.RespondAsync($"Unmet precondition: {result.ErrorReason}");
+                            await context.Interaction.RespondAsync($"Unmet precondition for user <@{context.User.Id}>: {result.ErrorReason}", allowedMentions: AllowedMentions.None);
                         _logger.SendLog(LogEventLevel.Warning, context.Guild.Id, result.ErrorReason, caller: info.MethodName);
                         break;
                     default:
                         if (context.Interaction.HasResponded)
                             await context.Interaction.FollowupAsync($"An error occurred while executing: {result.ErrorReason}");
                         else
-                        await context.Interaction.RespondAsync($"An error occurred while executing: {result.ErrorReason}");
+                            await context.Interaction.RespondAsync($"An error occurred while executing: {result.ErrorReason}");
+                        _logger.SendLog(LogEventLevel.Warning, context.Guild.Id, result.ErrorReason, caller: info.MethodName);
                         break;
                 }
             }

--- a/PS2 Assistant/Handlers/NicknameHandler.cs
+++ b/PS2 Assistant/Handlers/NicknameHandler.cs
@@ -1,0 +1,138 @@
+﻿using System.Text.RegularExpressions;
+using Microsoft.Extensions.Configuration;
+
+using Discord;
+using Discord.Interactions;
+
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+
+using Serilog.Events;
+
+using PS2_Assistant.Data;
+using PS2_Assistant.Logger;
+using PS2_Assistant.Models.Census.API;
+using PS2_Assistant.Models.Database;
+using Microsoft.IdentityModel.Tokens;
+
+namespace PS2_Assistant.Handlers
+{
+    public class NicknameHandler
+    {
+        private readonly BotContext _guildDb;
+        private readonly SourceLogger _logger;
+        private readonly AssistantUtils _assistantUtils;
+        private readonly HttpClient _httpClient;
+        private readonly IConfiguration _configuration;
+
+        public NicknameHandler(BotContext guildDb, SourceLogger logger, AssistantUtils assistantUtils, HttpClient httpClient, IConfiguration configuration)
+        {
+            _guildDb = guildDb;
+            _logger = logger;
+            _assistantUtils = assistantUtils;
+            _httpClient = httpClient;
+            _configuration = configuration;
+        }
+
+        public async Task VerifyNicknameAsync(SocketInteractionContext context, string nickname, IGuildUser targetUser)
+        {
+            var findGuild = _guildDb.GetGuildByGuildIdAsync(context.Guild.Id);
+
+            //  Validate given nickname
+            nickname = nickname.Trim();
+            if (Regex.IsMatch(nickname, @"[\s]"))
+            {
+                _logger.SendLog(LogEventLevel.Information, context.Guild.Id, "User {UserId} submitted an invalid username: {nickname}", targetUser.Id, nickname);
+                await context.Interaction.ModifyOriginalResponseAsync(x => x.Content = $"Invalid nickname submitted: {nickname}. Whitespace are not allowed. Please try again.");
+                return;
+            }else if (nickname.IsNullOrEmpty())
+            {
+                _logger.SendLog(LogEventLevel.Information, context.Guild.Id, "User {UserId} submitted an empty username", targetUser.Id, nickname);
+                await context.Interaction.ModifyOriginalResponseAsync(x => x.Content = $"Invalid nickname submission: no empty nickname allowed.");
+                return;
+            }
+            _logger.SendLog(LogEventLevel.Information, context.Guild.Id, "User {UserId} submitted nickname: {nickname}", targetUser.Id, nickname);
+
+            //  Request players with this name from Census, including a few other, similar names
+            string outfitDataJson = await _httpClient.GetStringAsync($"http://census.daybreakgames.com/s:{_configuration.GetConnectionString("CensusAPIKey")}/get/ps2:v2/{PlayerDataLight.CollectionQuery}&name.first_lower=*{nickname.ToLower()}");
+
+            JsonSerializer serializer = new()
+            {
+                ContractResolver = new DefaultContractResolver() { NamingStrategy = new SnakeCaseNamingStrategy() }
+            };
+            var returnedData = JsonConvert.DeserializeObject<CensusObjectWrapper>(outfitDataJson);
+            if (returnedData?.Data?["character_name_list"].ToObject<List<PlayerDataLight>>(serializer) is List<PlayerDataLight> playerData && returnedData.Returned.HasValue)
+            {
+                //  If 0 is returned, no similar names were found. If more than 1 are returned and the first result is incorrect, no exact match was found
+                if (returnedData.Returned == 0 || returnedData.Returned > 1 && playerData[0].Name.FirstLower != nickname.ToLower())
+                {
+                    _logger.SendLog(LogEventLevel.Information, context.Guild.Id, "Unable to find a match for name {nickname} in the Census database. Dumping returned JSON string as a debug log message.", nickname);
+                    _logger.SendLog(LogEventLevel.Debug, context.Guild.Id, "Unable to find match for {nickname} using Census API. Returned JSON:\n{json}", nickname, outfitDataJson);
+                    await context.Interaction.ModifyOriginalResponseAsync(x => x.Content = $"No exact match found for {nickname}. Please try again.");
+                    return;
+                }
+
+                //  Check whether a database entry exists for this guild, before trying to access it
+                Guild? guild = await findGuild;
+                if (guild is null)
+                {
+                    _logger.SendLog(LogEventLevel.Error, context.Guild.Id, "No guild data found in database for this guild");
+                    await context.Interaction.ModifyOriginalResponseAsync(x => x.Content = "Something went horribly wrong... No data found for this server. Please contact the developer of the bot.");
+                    return;
+                }
+
+                //  Set the Discord nickname of the user, including outfit tag and either the member or non-member role, as defined by the guild admin
+                string? alias = playerData[0].Outfit.Alias;
+                //  Check whether a user with nickname already exists on the server, to prevent impersonation
+                if (guild.Users.Where(x => x.CharacterName == nickname && x.SocketUserId != targetUser.Id).FirstOrDefault(defaultValue: null) is User impersonatedUser)
+                {
+                    _logger.SendLog(LogEventLevel.Warning, context.Guild.Id, "Possible impersonation: user {UserId} tried to set nickname to {nickname}, but that character already exists in this guild!", targetUser.Id, nickname);
+                    await context.Interaction.FollowupAsync($"User {targetUser.Mention} tried to set his nickname to {nickname}, but user <@{impersonatedUser.SocketUserId}> already exists on the server! Incident reported...");
+                    await _assistantUtils.SendLogChannelMessageAsync(context.Guild.Id, $"User {targetUser.Mention} tried to set nickname to \"{nickname}\", but that user already exists on this server (<@{impersonatedUser.SocketUserId}>)");
+                    return;
+                }
+
+                try
+                {
+                    //  Assign Discord nickname and member/non-member role
+                    await targetUser.ModifyAsync(x => x.Nickname = $"[{alias}] {nickname}");
+                    if (guild.OutfitTag is not null && alias?.ToLower() == guild.OutfitTag.ToLower() && guild.Roles?.MemberRole is ulong memberRoleId)
+                    {
+                        await targetUser.AddRoleAsync(memberRoleId);
+                        _logger.SendLog(LogEventLevel.Information, context.Guild.Id, "Added role {MemberRoleId} to user {UserId}", memberRoleId, targetUser.Id);
+                    }
+                    else if (guild.OutfitTag is not null && alias?.ToLower() != guild.OutfitTag.ToLower() && guild.Roles?.NonMemberRole is ulong nonMemberRoleId)
+                    {
+                        await targetUser.AddRoleAsync(nonMemberRoleId);
+                        _logger.SendLog(LogEventLevel.Information, context.Guild.Id, "Added role {NonMemberId} to user {UserId}", nonMemberRoleId, targetUser.Id);
+                    }
+
+                    await context.Interaction.ModifyOriginalResponseAsync(x => { x.Content = $"Nickname set to {targetUser.Mention}"; x.AllowedMentions = AllowedMentions.None; });
+                    if(context.User.Id == targetUser.Id)
+                        await context.Interaction.FollowupAsync($"We've now set your Discord nickname to your in-game name, to avoid potential confusion during tense moments.\nWith that you're all set, thanks for joining and have fun!", ephemeral: true);
+                }
+                catch (Exception ex)
+                {
+                    _logger.SendLog(LogEventLevel.Warning, context.Guild.Id, "Unable to assign nickname to user {UserId}. Encountered exception:", targetUser.Id, exep: ex);
+                    await context.Interaction.ModifyOriginalResponseAsync(x => x.Content = $"Something went wrong when trying to set <@{targetUser.Id}>'s nickname to \"[{alias}] {nickname}\"...\nPlease contact an admin to have them set the nickname!");
+                }
+
+                //  Check whether user already exists in the database for this guild
+                if (guild.Users.Where(x => x.SocketUserId == targetUser.Id).FirstOrDefault(defaultValue: null) is User user)
+                {
+                    user.CharacterName = nickname;
+                    user.CurrentOutfit = alias;
+                }
+                else
+                    guild.Users.Add(new User { CharacterName = nickname, CurrentOutfit = alias, SocketUserId = targetUser.Id });
+                await _guildDb.SaveChangesAsync();
+            }
+            else
+            {
+                _logger.SendLog(LogEventLevel.Warning, context.Guild.Id, "Census failed to return a list of names. Dumping returned JSON as a debug log message");
+                _logger.SendLog(LogEventLevel.Debug, context.Guild.Id, "Returned Census JSON: {json}", outfitDataJson);
+                await context.Interaction.ModifyOriginalResponseAsync(x => x.Content = $"Whoops, something went wrong... Unable to find that user due to an error in the Census database.");
+            }
+        }
+    }
+}

--- a/PS2 Assistant/Modules/ButtonModule.cs
+++ b/PS2 Assistant/Modules/ButtonModule.cs
@@ -23,5 +23,13 @@ namespace PS2_Assistant.Modules
 
             await RespondWithModalAsync<ModalModule.NicknameModal>("nickname-modal");
         }
+
+        public static MessageComponent RegisterUserButtons(ulong userId)
+        {
+            var buttons = new ComponentBuilder()
+                .WithButton("Yes, Register User", $"put-user-in-register-list:{true},{userId}")
+                .WithButton("No, Skip User", $"put-user-in-register-list:{false},{userId}");
+            return buttons.Build();
+        }
     }
 }

--- a/PS2 Assistant/Modules/ModalModule.cs
+++ b/PS2 Assistant/Modules/ModalModule.cs
@@ -1,37 +1,18 @@
-﻿using System.Text.RegularExpressions;
-
-using Microsoft.Extensions.Configuration;
-using Serilog.Events;
-
-using Newtonsoft.Json;
-using Newtonsoft.Json.Serialization;
-
 using Discord;
 using Discord.Interactions;
 
 using PS2_Assistant.Attributes.Preconditions;
-using PS2_Assistant.Data;
-using PS2_Assistant.Logger;
-using PS2_Assistant.Models.Census.API;
-using PS2_Assistant.Models.Database;
+using PS2_Assistant.Handlers;
 
 namespace PS2_Assistant.Modules
 {
     public class ModalModule : InteractionModuleBase<SocketInteractionContext>
     {
-        private readonly SourceLogger _logger;
-        private readonly BotContext _guildDb;
-        private readonly HttpClient _httpClient;
-        private readonly AssistantUtils _assistantUtils;
-        private readonly IConfiguration _configuration;
+        private readonly NicknameHandler _nicknameHandler;
 
-        public ModalModule(SourceLogger logger, BotContext guildDb, HttpClient httpClient, AssistantUtils assistantUtils, IConfiguration configuration)
+        public ModalModule(NicknameHandler nicknameHandler)
         {
-            _logger = logger;
-            _guildDb = guildDb;
-            _httpClient = httpClient;
-            _assistantUtils = assistantUtils;
-            _configuration = configuration;
+            _nicknameHandler = nicknameHandler;
         }
 
         public class NicknameModal : IModal
@@ -43,115 +24,13 @@ namespace PS2_Assistant.Modules
             public string Nickname { get; set; } = "";
         }
 
+        [EnabledInDm(false)]
         [NeedsDatabaseEntry]
         [ModalInteraction("nickname-modal")]
         public async Task NicknameModalInteraction(NicknameModal modal)
         {
-            await RespondAsync("Validating character name...");
-            
-            string nickname = modal.Nickname;
-
-            var findGuild = _guildDb.GetGuildByGuildIdAsync(Context.Guild.Id);
-
-            //  Validate given nickname
-            nickname = nickname.Trim();
-            if (Regex.IsMatch(nickname, @"[\s]"))
-            {
-                _logger.SendLog(LogEventLevel.Information, Context.Guild.Id, "User {UserId} submitted an invalid username: {nickname}", Context.User.Id, nickname);
-                await ModifyOriginalResponseAsync(x => x.Content = $"Invalid nickname submitted: {nickname}. Whitespace are not allowed. Please try again.");
-                return;
-            }
-            _logger.SendLog(LogEventLevel.Information, Context.Guild.Id, "User {UserId} submitted nickname: {nickname}", Context.User.Id, nickname);
-
-            //  Request players with this name from Census, including a few other, similar names
-            string outfitDataJson = await _httpClient.GetStringAsync($"http://census.daybreakgames.com/s:{_configuration.GetConnectionString("CensusAPIKey")}/get/ps2:v2/{PlayerDataLight.CollectionQuery}&name.first_lower=*{nickname.ToLower()}");
-
-            JsonSerializer serializer = new()
-            {
-                ContractResolver = new DefaultContractResolver() { NamingStrategy = new SnakeCaseNamingStrategy() }
-            };
-            var returnedData = JsonConvert.DeserializeObject<CensusObjectWrapper>(outfitDataJson);
-            if (returnedData?.Data?["character_name_list"].ToObject<List<PlayerDataLight>>(serializer) is List<PlayerDataLight> playerData && returnedData.Returned.HasValue)
-            {
-                //  If 0 is returned, no similar names were found. If more than 1 are returned and the first result is incorrect, no exact match was found
-                if (returnedData.Returned == 0 || returnedData.Returned > 1 && playerData[0].Name.FirstLower != nickname.ToLower())
-                {
-                    _logger.SendLog(LogEventLevel.Information, Context.Guild.Id, "Unable to find a match for name {nickname} in the Census database. Dumping returned JSON string as a debug log message.", nickname);
-                    _logger.SendLog(LogEventLevel.Debug, Context.Guild.Id, "Unable to find match for {nickname} using Census API. Returned JSON:\n{json}", nickname, outfitDataJson);
-                    await ModifyOriginalResponseAsync(x => x.Content = $"No exact match found for {nickname}. Please try again.");
-                    return;
-                }
-
-                //  Check whether a database entry exists for this guild, before trying to access it
-                Guild? guild = await findGuild;
-                if (guild is null)
-                {
-                    _logger.SendLog(LogEventLevel.Error, Context.Guild.Id, "No guild data found in database for this guild");
-                    await ModifyOriginalResponseAsync(x => x.Content = "Something went horribly wrong... No data found for this server. Please contact the developer of the bot.");
-                    return;
-                }
-
-                //  Set the Discord nickname of the user, including outfit tag and either the member or non-member role, as defined by the guild admin
-                string? alias = playerData[0].Outfit.Alias;
-                if (Context.User is IGuildUser guildUser)
-                {
-
-                    //  Check whether a user with nickname already exists on the server, to prevent impersonation
-                    if (guild.Users.Where(x => x.CharacterName == nickname && x.SocketUserId != Context.User.Id).FirstOrDefault(defaultValue: null) is User impersonatedUser)
-                    {
-                        _logger.SendLog(LogEventLevel.Warning, Context.Guild.Id, "Possible impersonation: user {UserId} tried to set nickname to {nickname}, but that character already exists in this guild!", Context.User.Id, nickname);
-                        await FollowupAsync($"User {Context.User.Mention} tried to set his nickname to {nickname}, but user <@{impersonatedUser.SocketUserId}> already exists on the server! Incident reported...");
-                        await _assistantUtils.SendLogChannelMessageAsync(Context.Guild.Id, $"User {Context.User.Mention} tried to set nickname to \"{nickname}\", but that user already exists on this server (<@{impersonatedUser.SocketUserId}>)");
-                        return;
-                    }
-
-                    try
-                    {
-                        //  Assign Discord nickname and member/non-member role
-                        await guildUser.ModifyAsync(x => x.Nickname = $"[{alias}] {nickname}");
-                        if (guild.OutfitTag is not null && alias?.ToLower() == guild.OutfitTag.ToLower() && guild.Roles?.MemberRole is ulong memberRoleId)
-                        {
-                            await guildUser.AddRoleAsync(memberRoleId);
-                            _logger.SendLog(LogEventLevel.Information, Context.Guild.Id, "Added role {MemberRoleId} to user {UserId}", memberRoleId, Context.User.Id);
-                        }
-                        else if (guild.OutfitTag is not null && alias?.ToLower() != guild.OutfitTag.ToLower() && guild.Roles?.NonMemberRole is ulong nonMemberRoleId)
-                        {
-                            await guildUser.AddRoleAsync(nonMemberRoleId);
-                            _logger.SendLog(LogEventLevel.Information, Context.Guild.Id, "Added role {NonMemberId} to user {UserId}", nonMemberRoleId, Context.User.Id);
-                        }
-
-                        await ModifyOriginalResponseAsync(x => { x.Content = $"Nickname set to {guildUser.Mention}"; x.AllowedMentions = AllowedMentions.None; });
-                        await FollowupAsync($"We've now set your Discord nickname to your in-game name, to avoid potential confusion during tense moments.\nWith that you're all set, thanks for joining and have fun!", ephemeral: true);
-                    }
-                    catch (Exception ex)
-                    {
-                        _logger.SendLog(LogEventLevel.Warning, Context.Guild.Id, "Unable to assign nickname to user {UserId}. Encountered exception:", Context.User.Id, exep: ex);
-                        await ModifyOriginalResponseAsync(x => x.Content = $"Something went wrong when trying to set your nickname to \"[{alias}] {nickname}\"...\nPlease contact an admin to have them set the nickname!");
-                    }
-
-                    //  Check whether user already exists in the database for this guild
-                    if (guild.Users.Where(x => x.SocketUserId == Context.User.Id).FirstOrDefault(defaultValue: null) is User user)
-                    {
-                        user.CharacterName = nickname;
-                        user.CurrentOutfit = alias;
-                    }
-                    else
-                        guild.Users.Add(new User { CharacterName = nickname, CurrentOutfit = alias, SocketUserId = Context.User.Id });
-                    await _guildDb.SaveChangesAsync();
-                }
-                else
-                {
-                    _logger.SendLog(LogEventLevel.Warning, Context.Guild.Id, "Could not convert user {UserId} from SocketUser to IGuildUser", Context.User.Id);
-                    await ModifyOriginalResponseAsync(x => x.Content = $"Something went wrong when trying to set your nickname to \"[{alias}] {nickname}\"...\nPlease contact an admin to have them set the nickname!");
-                }
-
-            }
-            else
-            {
-                _logger.SendLog(LogEventLevel.Warning, Context.Guild.Id, "Census failed to return a list of names. Dumping returned JSON as a debug log message");
-                _logger.SendLog(LogEventLevel.Debug, Context.Guild.Id, "Returned Census JSON: {json}", outfitDataJson);
-                await ModifyOriginalResponseAsync(x => x.Content = $"Whoops, something went wrong... Unable to find that user due to an error in the Census database.");
-            }
+            await RespondAsync("Validating character name...", allowedMentions: AllowedMentions.None);
+            await _nicknameHandler.VerifyNicknameAsync(Context, modal.Nickname, (IGuildUser)Context.User);
         }
     }
 }

--- a/PS2 Assistant/Modules/NicknameModule.cs
+++ b/PS2 Assistant/Modules/NicknameModule.cs
@@ -1,9 +1,16 @@
-﻿using Discord;
+﻿using System.Text.RegularExpressions;
+using Microsoft.IdentityModel.Tokens;
+
+using Discord;
 using Discord.Interactions;
+using Discord.WebSocket;
+
+using Serilog.Events;
 
 using PS2_Assistant.Attributes;
 using PS2_Assistant.Attributes.Preconditions;
 using PS2_Assistant.Data;
+using PS2_Assistant.Handlers;
 using PS2_Assistant.Logger;
 
 namespace PS2_Assistant.Modules
@@ -11,11 +18,13 @@ namespace PS2_Assistant.Modules
     [EnabledInDm(false)]
     public class NicknameModule : InteractionModuleBase<SocketInteractionContext>
     {
+        private readonly NicknameHandler _nicknameHandler;
         private readonly BotContext _guildDb;
         private readonly SourceLogger _logger;
 
-        public NicknameModule(BotContext guildDb, SourceLogger sourceLogger)
+        public NicknameModule(NicknameHandler nicknameHandler, BotContext guildDb, SourceLogger sourceLogger)
         {
+            _nicknameHandler = nicknameHandler;
             _guildDb = guildDb;
             _logger = sourceLogger;
         }
@@ -51,6 +60,37 @@ namespace PS2_Assistant.Modules
 
         }
 
+        [NeedsDatabaseEntry]
+        [DefaultMemberPermissions(GuildPermission.ManageGuild)]
+        [SlashCommand("register-users-manually", "Asks you for each user whether their Discord nickname is equal to their in-game character name")]
+        public async Task RegisterUsersManually(SocketGuildUser user)
+        {
+            //  The Users collection is not guaranteed to be up to date. If it's not, all users will have to be downloaded
+            if (Context.Guild.Users.Count != Context.Guild.MemberCount)
+                await Context.Guild.DownloadUsersAsync();
+
+            _logger.SendLog(LogEventLevel.Information, Context.Guild.Id, $"User {Context.User.Id} started to register users manually");
+            await RespondAsync($"Does the nickname of user <@{Context.Guild.Users.ElementAt(0).Id}> equal their in-game username?", components: ButtonModule.RegisterUserButtons(Context.Guild.Users.ElementAt(0).Id), allowedMentions: AllowedMentions.None);
+        }
+
+        [NeedsDatabaseEntry]
+        [RequireGuildPermission(GuildPermission.ManageGuild)]
+        [SlashCommand("register-selected-users", "Registers the users that have been selected using /register-users-manually")]
+        public async Task RegisterSelectedUsers()
+        {
+            await RespondAsync("Registering users...");
+            foreach (var userId in ButtonModule.usersToRegister[Context.Guild.Id])
+            {
+                IGuildUser userToRegister = Context.Guild.GetUser(userId);
+                string nickname = userToRegister.Nickname.IsNullOrEmpty() ? userToRegister.DisplayName : userToRegister.Nickname;
+
+                //  exclude potential outfit tags from the nickname
+                nickname = Regex.Split(nickname, @"(?<=[\[\]])").First(x => !x.Contains('[') && !x.Contains(']')).Trim();
+
+                await _nicknameHandler.VerifyNicknameAsync(Context, nickname, userToRegister);
+            }
+        }
+
         /// <summary>
         /// Sends a message asking the user to start the nickname process by pressing a button.
         /// </summary>
@@ -66,6 +106,6 @@ namespace PS2_Assistant.Modules
                     .WithButton("Get Started", "start-nickname-process");
 
             await channel.SendMessageAsync("To get started, press this button so we can set you up properly:", components: confirmationButton.Build());
-            }
+        }
     }
 }

--- a/PS2 Assistant/Modules/NicknameModule.cs
+++ b/PS2 Assistant/Modules/NicknameModule.cs
@@ -62,7 +62,7 @@ namespace PS2_Assistant.Modules
 
         [NeedsDatabaseEntry]
         [DefaultMemberPermissions(GuildPermission.ManageGuild)]
-        [SlashCommand("register-users-manually", "Asks you for each user whether their Discord nickname is equal to their in-game character name")]
+        [SlashCommand("register-users-manually", "Asks whether a users Discord nickname matches their in-game name and marks them to be registered")]
         public async Task RegisterUsersManually(
             [Summary(description: "If specified, only this user will be registered")]
             SocketGuildUser? userToRegister = null)


### PR DESCRIPTION
This PR adds the ability for moderators to register (verify the nickname of) either specific users or all users at once. The following slash commands were added:
`/register-users-manually`
`/register-selected-users`