### PR TITLE
Provide log files on-demand

### DIFF
--- a/PS2 Assistant/AssistantUtils.cs
+++ b/PS2 Assistant/AssistantUtils.cs
@@ -11,6 +11,7 @@ namespace PS2_Assistant
     public class AssistantUtils
     {
         public const ChannelPermission channelWritePermissions = ChannelPermission.ViewChannel | ChannelPermission.SendMessages;
+        public const string logFilePath = "Logs";
 
         private readonly DiscordSocketClient _client;
         private readonly SourceLogger _logger;

--- a/PS2 Assistant/Attributes/BotOwnerCommandAttribute.cs
+++ b/PS2 Assistant/Attributes/BotOwnerCommandAttribute.cs
@@ -1,0 +1,11 @@
+﻿namespace PS2_Assistant.Attributes
+{
+    /// <summary>
+    /// Marks the (sub)module as only being accessible to the owner of the bot (on the test server)
+    /// </summary>
+    [System.AttributeUsage(AttributeTargets.All, Inherited = false, AllowMultiple = true)]
+    sealed class BotOwnerCommandAttribute : Attribute
+    {
+        public BotOwnerCommandAttribute() { }
+    }
+}

--- a/PS2 Assistant/Handlers/InteractionHandler.cs
+++ b/PS2 Assistant/Handlers/InteractionHandler.cs
@@ -7,6 +7,7 @@ using Discord;
 using Discord.Interactions;
 using Discord.WebSocket;
 
+using PS2_Assistant.Attributes;
 using PS2_Assistant.Logger;
 
 namespace PS2_Assistant.Handlers
@@ -86,6 +87,13 @@ namespace PS2_Assistant.Handlers
             await _interactionService.AddModulesToGuildAsync(Convert.ToUInt64(_configuration.GetConnectionString("TestGuildId")), modules: _interactionService.Modules.Where(x => x.DontAutoRegister == true).ToArray());
 #else
             await _interactionService.RegisterCommandsGloballyAsync(true);
+            //  Allow (sub)modules marked with the BotOwnerCommand to be accessed from the test server
+            await _interactionService.AddModulesToGuildAsync(Convert.ToUInt64(_configuration.GetConnectionString("TestGuildId")),
+                modules: _interactionService.Modules
+                .Where(x =>
+                    x.Attributes.Any(attr =>
+                        attr.GetType() == typeof(BotOwnerCommandAttribute)))
+                .ToArray());
 #endif
             _logger.SendLog(LogEventLevel.Information, null, "Bot ready");
         }

--- a/PS2 Assistant/Modules/SlashCommands/Slashcommands.Diagnostics.cs
+++ b/PS2 Assistant/Modules/SlashCommands/Slashcommands.Diagnostics.cs
@@ -1,12 +1,13 @@
 ﻿using Discord;
 using Discord.Interactions;
-
+using PS2_Assistant.Attributes;
 using PS2_Assistant.Logger;
 
 namespace PS2_Assistant.Modules.SlashCommands
 {
     public partial class Slashcommands
     {
+        [BotOwnerCommand]
         [DontAutoRegister]
         [EnabledInDm(false)]
         [Group("diagnostics", "returns various types of diagnostic data")]

--- a/PS2 Assistant/Modules/SlashCommands/Slashcommands.Diagnostics.cs
+++ b/PS2 Assistant/Modules/SlashCommands/Slashcommands.Diagnostics.cs
@@ -58,8 +58,17 @@ namespace PS2_Assistant.Modules.SlashCommands
                     else
                     {
                         _logger.SendLog(Serilog.Events.LogEventLevel.Debug, Context.Guild.Id, "Sending log file {LogFileName}", file.Name);
-                        Stream fileStream = new StreamReader(file.FullName).BaseStream;
-                        requestedLogFiles.Add(new(fileStream, file.Name));
+
+                        try
+                        {
+                            FileStream fileStream = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
+                            Stream streamReader = new StreamReader(fileStream, encoding: System.Text.Encoding.Default).BaseStream;
+                            requestedLogFiles.Add(new(streamReader, file.Name));
+                        }
+                        catch (Exception ex)
+                        {
+                            await FollowupAsync($"Failed with the following execption: `{ex.Message}`\nWith stacktrace: ```{ex.StackTrace}```");
+                        }
                     }
                 }
 

--- a/PS2 Assistant/Modules/SlashCommands/Slashcommands.Diagnostics.cs
+++ b/PS2 Assistant/Modules/SlashCommands/Slashcommands.Diagnostics.cs
@@ -1,0 +1,74 @@
+﻿using Discord;
+using Discord.Interactions;
+
+using PS2_Assistant.Logger;
+
+namespace PS2_Assistant.Modules.SlashCommands
+{
+    public partial class Slashcommands
+    {
+        [DontAutoRegister]
+        [EnabledInDm(false)]
+        [Group("diagnostics", "returns various types of diagnostic data")]
+        public class Diagnostics : InteractionModuleBase<SocketInteractionContext>
+        {
+            private readonly SourceLogger _logger;
+
+            public Diagnostics(SourceLogger logger)
+            {
+                _logger = logger;
+            }
+
+            [SlashCommand("send-log-file", "Returns a log file")]
+            public async Task SendLogFile(
+                [Summary(description: "The date at which the log file was created")]
+                DateTime logDate,
+                [Summary(description: "When specified, returns all log files created between log-date and last-log-date")]
+                DateTime? lastLogDate = null)
+            {
+                //  Ensure logDate is the earliest of the two
+                if (lastLogDate is not null && logDate.Date > lastLogDate?.Date)
+                    (logDate, lastLogDate) = (lastLogDate.Value, logDate);
+
+                await RespondAsync($"Retrieving log file(s) for {logDate:yyyy-MM-dd}{(lastLogDate is null ? "" : " - " + lastLogDate?.ToString("yyyy-MM-dd"))}...");
+                _logger.SendLog(Serilog.Events.LogEventLevel.Information, Context.Guild.Id, "Log files requested by user {UserId} for date range {FirstDate} - {SecondDate}", Context.User.Id, logDate.ToString("yyyy-MM-dd"), lastLogDate?.ToString("yyyy-MM-dd"));
+
+                //  Find all logs in the log file directory
+                List<FileAttachment> requestedLogFiles = new();
+                FileInfo[] logFiles = new DirectoryInfo($"{AssistantUtils.logFilePath}").GetFiles();
+                foreach ( FileInfo file in logFiles )
+                {
+                    DateTime creationDate = file.CreationTime.Date;
+
+                    //  Only add the log file if it was created at the specified date or withing the specified range
+                    if (creationDate != logDate.Date)
+                    {
+                        if (lastLogDate is not null)
+                        {
+                            if (!(creationDate >= logDate.Date && creationDate <= lastLogDate?.Date))
+                                continue;
+                        }
+                        else
+                            continue;
+                    }
+
+                    //  Only try to send the file if it doen't exceed the file limit for the server
+                    if ((ulong)file.Length > Context.Guild.MaxUploadLimit)
+                        await FollowupAsync($"Can't send file {file.Name} in this server! The file size is {file.Length}, while the upload limit for this server is {Context.Guild.MaxUploadLimit} bytes");
+                    else
+                    {
+                        _logger.SendLog(Serilog.Events.LogEventLevel.Debug, Context.Guild.Id, "Sending log file {LogFileName}", file.Name);
+                        Stream fileStream = new StreamReader(file.FullName).BaseStream;
+                        requestedLogFiles.Add(new(fileStream, file.Name));
+                    }
+                }
+
+                //  Send all log files that were found for the specified date
+                if (requestedLogFiles.Count > 0)
+                    await FollowupWithFilesAsync(requestedLogFiles);
+                else
+                    await FollowupAsync($"No log files found for that {(lastLogDate is null ? "date" : "range of dates")}");
+            }
+        }
+    }
+}

--- a/PS2 Assistant/Program.cs
+++ b/PS2 Assistant/Program.cs
@@ -45,7 +45,7 @@ public class Program
         ILogger sLogger = new LoggerConfiguration()
             .MinimumLevel.Debug()
             .Enrich.FromLogContext()
-            .WriteTo.File(new JsonFormatter(), "Logs/log.json", rollingInterval: RollingInterval.Day)
+            .WriteTo.File(new JsonFormatter(), $"{AssistantUtils.logFilePath}/log.json", rollingInterval: RollingInterval.Day)
             .WriteTo.Seq(_appSettings.GetConnectionString("LoggerURL")!, apiKey: _appSettings.GetConnectionString("LoggerAPIKey"))
             .WriteTo.Console(expression)
             .CreateLogger();


### PR DESCRIPTION
Allows the bot owner to access log files using the send-log-files slashcommand. Either a single file, or a range of files.